### PR TITLE
fix: upgrade for 0.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "homepage": "https://github.com/moshisushi/hlsjs-ipfs-loader#readme",
   "dependencies": {
     "aegir": "^11.0.2",
-    "gulp": "^3.9.1",
-    "lodash": "^4.17.4"
+    "gulp": "^3.9.1"
   }
 }


### PR DESCRIPTION
JS IPFS v0.34 is coming out soon. It has breaking changes. This PR addresses those issues. I've tested this against v0.34.0-rc.1 in the [browser video streaming example](https://github.com/ipfs/js-ipfs/tree/master/examples/browser-video-streaming) and it all works.

This PR also improves the code by actually streaming the file using `catReadableStream` over `cat` (which buffers content in memory).