### PR TITLE
Update to new IPFS API

### DIFF
--- a/examples/basic_usage.html
+++ b/examples/basic_usage.html
@@ -5,34 +5,34 @@
     <script src="../dist/index.js"></script>
 
     <script>
-if (window.ipfs === undefined) {
-  const repoPath = 'ipfs-' + Math.random()
-  const node = new Ipfs({
-    init: false,
-    start: false,
-    repo: repoPath
-  })
-  node.init().then(() => node.start()).then(() => handleInit(node))
-} else {
-  window.ipfs.enable().then(handleInit)
-}
-
-function handleInit(node) {
-  const testhash = "QmdpAidwAsBGptFB3b6A9Pyi5coEbgjHrL3K2Qrsutmj9K";
-  Hls.DefaultConfig.loader = HlsjsIpfsLoader;
-  Hls.DefaultConfig.debug = false;
-  if (Hls.isSupported()) {
-    const video = document.getElementById('video');
-    const hls = new Hls();
-    hls.config.ipfs = node;
-    hls.config.ipfsHash = testhash;
-    hls.loadSource('master.m3u8');
-    hls.attachMedia(video);
-    hls.on(Hls.Events.MANIFEST_PARSED, () => {
-      video.play();
-    });
+(async () => {
+  if (window.ipfs === undefined) {
+    const repoPath = 'ipfs-' + Math.random()
+    const node = await Ipfs.create({
+      repo: repoPath
+    })
+    handleInit(node)
+  } else {
+    window.ipfs.enable().then(handleInit)
   }
-}
+
+  function handleInit(node) {
+    const testhash = "QmdpAidwAsBGptFB3b6A9Pyi5coEbgjHrL3K2Qrsutmj9K";
+    Hls.DefaultConfig.loader = HlsjsIpfsLoader;
+    Hls.DefaultConfig.debug = false;
+    if (Hls.isSupported()) {
+      const video = document.getElementById('video');
+      const hls = new Hls();
+      hls.config.ipfs = node;
+      hls.config.ipfsHash = testhash;
+      hls.loadSource('master.m3u8');
+      hls.attachMedia(video);
+      hls.on(Hls.Events.MANIFEST_PARSED, () => {
+        video.play();
+      });
+    }
+  }
+})()
     </script>
 
     <video id="video" controls></video>


### PR DESCRIPTION
The IPFS API is undergoing a massive refactoring effort to make it all async iterables.  We're pretty close to landing that PR, you can check out the code at the [ipfs/js-ipfs#async-await-roundup](https://github.com/ipfs/js-ipfs/tree/refactor/async-await-roundup) branch and the API docs at [ipfs/interface-js-ipfs-core#refactor/async-iterables/SPEC](https://github.com/ipfs/interface-js-ipfs-core/tree/refactor/async-iterables/SPEC).

This PR updates the code & example for `hlsjs-ipfs-loader` to use the new API.