### PR TITLE
feat: support for ipfs directories

### DIFF
--- a/examples/basic_usage.html
+++ b/examples/basic_usage.html
@@ -1,6 +1,6 @@
 <html>
   <body>
-    <script src="https://unpkg.com/ipfs/dist/index.js"></script>
+    <script src="https://unpkg.com/ipfs/dist/index.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
     <script src="../dist/index.js"></script>
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,12 @@ class HlsjsIPFSLoader {
     stats.tfirst = Math.max(performance.now(), stats.trequest)
     stats.loaded = 0
 
-    const urlParts = context.url.split("/")
-    const filename = urlParts[urlParts.length - 1]
+    //When using absolute path (https://example.com/index.html) vs https://example.com/
+    const urlParts = window.location.href.split("/")
+    if(urlParts[urlParts.length - 1] !== "") {
+      urlParts[urlParts.length - 1] = ""
+    }
+    const filename = context.url.replace(urlParts.join("/"), "")
 
     const options = {}
     if (Number.isFinite(context.rangeStart)) {
@@ -115,12 +119,17 @@ class HlsjsIPFSLoader {
 
 async function getFile(ipfs, rootHash, filename, options, debug, abortFlag) {
   debug(`Fetching hash for '${rootHash}/${filename}'`)
+  const path = `${rootHash}/${filename}`
+  const pathParts = path.split("/")
+  const short_filename = pathParts.pop()
+  const basePath = pathParts.join("/")
+
   if(filename === null) {
     return cat(rootHash, options, ipfs, debug, abortFlag)
   }
 
-  for await (const link of ipfs.ls(rootHash)) {
-    if (link.name !== filename) {
+  for await (const link of ipfs.ls(basePath)) {
+    if (link.name !== short_filename) {
       continue
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -116,28 +116,14 @@ class HlsjsIPFSLoader {
     }, console.error)
   }
 }
-
 async function getFile(ipfs, rootHash, filename, options, debug, abortFlag) {
   debug(`Fetching hash for '${rootHash}/${filename}'`)
   const path = `${rootHash}/${filename}`
-  const pathParts = path.split("/")
-  const short_filename = pathParts.pop()
-  const basePath = pathParts.join("/")
-
-  if(filename === null) {
-    return cat(rootHash, options, ipfs, debug, abortFlag)
+  try {
+    return await cat(path, options, ipfs, debug, abortFlag)
+  } catch(ex) {
+    throw new Error(`File not found: ${rootHash}/${filename}`)
   }
-
-  for await (const link of ipfs.ls(basePath)) {
-    if (link.name !== short_filename) {
-      continue
-    }
-
-    debug(`Requesting '${link.path}'`, options)
-    return cat(link.cid, options, ipfs, debug, abortFlag)
-  }
-
-  throw new Error(`File not found: ${rootHash}/${filename}`)
 }
 
 function buf2str(buf) {


### PR DESCRIPTION
Passes full path to `ipfs.ls`. Backwards compatible, does not cause any compatibility issues with my tests.

fixes #19 
cc: @moshisushi 