### PR TITLE
refactor: config.ipfsHash is now optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,13 +116,14 @@ class HlsjsIPFSLoader {
     }, console.error)
   }
 }
+
 async function getFile(ipfs, rootHash, filename, options, debug, abortFlag) {
-  debug(`Fetching hash for '${rootHash}/${filename}'`)
-  const path = `${rootHash}/${filename}`
+  debug(`Fetching hash for '${ rootHash ? `${ rootHash }/` : ""}${ filename }'`);
+  const path = `${ rootHash ? `${ rootHash }/` : "" }${ filename }`;
   try {
     return await cat(path, options, ipfs, debug, abortFlag)
   } catch(ex) {
-    throw new Error(`File not found: ${rootHash}/${filename}`)
+    throw new Error(`File not found: ${ rootHash ? `${ rootHash }/` : "" }${filename}`)
   }
 }
 


### PR DESCRIPTION
`ipfsHash` supplied via `hls.config` will be prepended to the filename with an appended slash only when available. FIlename can now be a CID path (e.g. QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o/path/to/file).  It is backward compatible. Close #23. 