### PR TITLE
chore: make aegir a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ typings/
 .dynamodb/
 
 *-lock.json
+dist

--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
     "url": "https://github.com/moshisushi/hlsjs-ipfs-loader/issues"
   },
   "homepage": "https://github.com/moshisushi/hlsjs-ipfs-loader#readme",
-  "dependencies": {
-    "aegir": "^20.5.0"
-  }
+  "devDependencies": {
+    "aegir": "^35.0.3"
+  },
+  "files": [
+    "dist",
+    "examples",
+    "src"
+  ]
 }


### PR DESCRIPTION
- updates aegir to the latest version
- makes it a dev dependency
- ignores the dist folder for git
- configures npm to publish the dist, examples and src directories