### PR TITLE
Handle external URLs outside of IPFS

### DIFF
--- a/examples/basic_usage.html
+++ b/examples/basic_usage.html
@@ -18,12 +18,11 @@
 
   function handleInit(node) {
     const testhash = "QmdpAidwAsBGptFB3b6A9Pyi5coEbgjHrL3K2Qrsutmj9K";
-    Hls.DefaultConfig.loader = HlsjsIpfsLoader;
+    Hls.DefaultConfig.loader = HlsjsIPFSLoaderFactory(node);
     Hls.DefaultConfig.debug = false;
     if (Hls.isSupported()) {
       const video = document.getElementById('video');
       const hls = new Hls();
-      hls.config.ipfs = node;
       hls.config.ipfsHash = testhash;
       hls.loadSource('master.m3u8');
       hls.attachMedia(video);

--- a/src/index.js
+++ b/src/index.js
@@ -116,13 +116,14 @@ class HlsjsIPFSLoader {
     }, console.error)
   }
 }
+
 async function getFile(ipfs, rootHash, filename, options, debug, abortFlag) {
-  debug(`Fetching hash for '${rootHash}/${filename}'`)
-  const path = `${rootHash}/${filename}`
+  debug(`Fetching hash for '${ rootHash ? `${ rootHash }/` : ""}${ filename }'`);
+  const path = `${ rootHash ? `${ rootHash }/` : "" }${ filename }`;
   try {
     return await cat(path, options, ipfs, debug, abortFlag)
   } catch(ex) {
-    throw new Error(`File not found: ${rootHash}/${filename}`)
+    throw new Error(`File not found: ${ rootHash ? `${ rootHash }/` : "" }${filename}`)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,119 +1,109 @@
 'use strict'
-
-class HlsjsIPFSLoader {
-  constructor(config) {
-    this._abortFlag = [ false ];
-    this.ipfs = config.ipfs
-    this.hash = config.ipfsHash
-    if (config.debug === false) {
-      this.debug = function() {}
-    } else if (config.debug === true) {
-      this.debug = console.log
-    } else {
-      this.debug = config.debug
+function HlsjsIPFSLoaderFactory (ipfs) {
+  return class HlsjsIPFSLoader {
+    constructor(config) {
+      this._abortFlag = [false];
+      this.ipfs = ipfs;
+      this.hash = config.ipfsHash;
+      this.debug = config.debug === false ? function () {
+      } : config.debug === true ? console.log : config.debug;
+      this.m3u8provider = config.m3u8provider ? config.m3u8provider : null;
+      this.tsListProvider = config.tsListProvider ? config.tsListProvider : null;
     }
-    if(config.m3u8provider) {
-      this.m3u8provider = config.m3u8provider;
-    } else {
-      this.m3u8provider = null;
+
+    destroy() {
     }
-    if(config.tsListProvider) {
-      this.tsListProvider = config.tsListProvider;
-    } else {
-      this.tsListProvider = null;
+
+    abort() {
+      this._abortFlag[0] = true;
     }
-  }
 
-  destroy() {
-  }
-
-  abort() {
-    this._abortFlag[0] = true;
-  }
-
-  load(context, config, callbacks) {
-    this.context = context
-    this.config = config
-    this.callbacks = callbacks
-    this.stats = { trequest: performance.now(), retry: 0 }
-    this.retryDelay = config.retryDelay
-    this.loadInternal()
-  }
-  /**
-   * Call this by getting the HLSIPFSLoader instance from hls.js hls.coreComponents[0].loaders.manifest.setM3U8Provider()
-   * @param {function} provider
-   */
-  setM3U8Provider(provider) {
-    this.m3u8provider = provider;
-  }
-  /**
-   *
-   * @param {function} provider
-   */
-  setTsListProvider(provider) {
-    this.tsListProvider = provider;
-  }
-
-  loadInternal() {
-    const { stats, context, callbacks } = this
-
-    stats.tfirst = Math.max(performance.now(), stats.trequest)
-    stats.loaded = 0
-
-    //When using absolute path (https://example.com/index.html) vs https://example.com/
-    const urlParts = window.location.href.split("/")
-    if(urlParts[urlParts.length - 1] !== "") {
-      urlParts[urlParts.length - 1] = ""
+    load(context, config, callbacks) {
+      this.context = context
+      this.config = config
+      this.callbacks = callbacks
+      this.stats = {trequest: performance.now(), retry: 0}
+      this.retryDelay = config.retryDelay
+      this.loadInternal()
     }
-    const filename = context.url.replace(urlParts.join("/"), "")
 
-    const options = {}
-    if (Number.isFinite(context.rangeStart)) {
+    /**
+     * Call this by getting the HLSIPFSLoader instance from hls.js hls.coreComponents[0].loaders.manifest.setM3U8Provider()
+     * @param {function} provider
+     */
+    setM3U8Provider(provider) {
+      this.m3u8provider = provider;
+    }
+
+    /**
+     *
+     * @param {function} provider
+     */
+    setTsListProvider(provider) {
+      this.tsListProvider = provider;
+    }
+
+    loadInternal() {
+      const {stats, context, callbacks} = this
+
+      stats.tfirst = Math.max(performance.now(), stats.trequest)
+      stats.loaded = 0
+
+      //When using absolute path (https://example.com/index.html) vs https://example.com/
+      const urlParts = window.location.href.split("/")
+      if (urlParts[urlParts.length - 1] !== "") {
+        urlParts[urlParts.length - 1] = ""
+      }
+      const filename = context.url.replace(urlParts.join("/"), "")
+
+      const options = {}
+      if (Number.isFinite(context.rangeStart)) {
         options.offset = context.rangeStart;
         if (Number.isFinite(context.rangeEnd)) {
-	    options.length = context.rangeEnd - context.rangeStart;
+          options.length = context.rangeEnd - context.rangeStart;
         }
-    }
+      }
 
-    if(filename.split(".")[1] === "m3u8" && this.m3u8provider !== null) {
-      const res = this.m3u8provider();
-      let data;
-      if(Buffer.isBuffer(res)) {
-        data = buf2str(res)
-      } else {
-        data = res;
+      if (filename.split(".")[1] === "m3u8" && this.m3u8provider !== null) {
+        const res = this.m3u8provider();
+        let data;
+        if (Buffer.isBuffer(res)) {
+          data = buf2str(res)
+        } else {
+          data = res;
+        }
+        const response = {url: context.url, data: data}
+        callbacks.onSuccess(response, stats, context)
+        return;
       }
-      const response = { url: context.url, data: data }
-      callbacks.onSuccess(response, stats, context)
-      return;
-    }
-    if(filename.split(".")[1] === "m3u8" && this.tsListProvider !== null) {
-      var tslist = this.tsListProvider();
-      var hash = tslist[filename];
-      if(hash) {
-        this.cat(hash).then(res => {
-          let data;
-          if(Buffer.isBuffer(res)) {
-            data = buf2str(res)
-          } else {
-            data = res;
-          }
-          stats.loaded = stats.total = data.length
-          stats.tload = Math.max(stats.tfirst, performance.now())
-          const response = { url: context.url, data: data }
-          callbacks.onSuccess(response, stats, context)
-        });
+      if (filename.split(".")[1] === "m3u8" && this.tsListProvider !== null) {
+        var tslist = this.tsListProvider();
+        var hash = tslist[filename];
+        if (hash) {
+          this.cat(hash).then(res => {
+            let data;
+            if (Buffer.isBuffer(res)) {
+              data = buf2str(res)
+            } else {
+              data = res;
+            }
+            stats.loaded = stats.total = data.length
+            stats.tload = Math.max(stats.tfirst, performance.now())
+            const response = {url: context.url, data: data}
+            callbacks.onSuccess(response, stats, context)
+          });
+        }
+        return;
       }
-      return;
+      this._abortFlag[0] = false;
+      getFile(this.ipfs, this.hash, filename, options, this.debug, this._abortFlag).then(res => {
+        const data = (context.responseType === 'arraybuffer') ? res : buf2str(res)
+        stats.loaded = stats.total = data.length
+        stats.tload = Math.max(stats.tfirst, performance.now())
+        const response = {url: context.url, data: data}
+        callbacks.onSuccess(response, stats, context)
+      }, console.error)
     }
-    this._abortFlag[0] = false;
-    getFile(this.ipfs, this.hash, filename, options, this.debug, this._abortFlag).then(res => {
-      const data = (context.responseType === 'arraybuffer') ? res : buf2str(res)
-      stats.loaded = stats.total = data.length
-      stats.tload = Math.max(stats.tfirst, performance.now())
-      const response = { url: context.url, data: data }
-      callbacks.onSuccess(response, stats, context)
-    }, console.error)
   }
 }
 async function getFile(ipfs, rootHash, filename, options, debug, abortFlag) {
@@ -153,4 +143,4 @@ async function cat (cid, options, ipfs, debug, abortFlag) {
   return value
 }
 
-exports = module.exports = HlsjsIPFSLoader
+exports = module.exports = HlsjsIPFSLoaderFactory;

--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,17 @@ function HlsjsIPFSLoaderFactory (ipfs) {
 }
 
 async function getFile(ipfs, rootHash, filename, options, debug, abortFlag) {
+  // Handle external URLs outside of IPFS
+  if (filename.match(/^https?:\/\//)) {
+    debug(`External URL detected, falling back to fetch(${filename})`)
+    const response = await fetch(filename)
+    if (!response.ok) {
+      throw new Error('Failed to fetch external URL: ' + path + ', response.status: ' + response.status);
+    } else {
+      return await response.arrayBuffer();
+    }
+  }
+
   debug(`Fetching hash for '${ rootHash ? `${ rootHash }/` : ""}${ filename }'`);
   const path = `${ rootHash ? `${ rootHash }/` : "" }${ filename }`;
   try {


### PR DESCRIPTION
Implements fallback to `Fetch` for external URLs.  Tested against an .m3u8 that contains #EXT-X-KEY pointing to an external HTTPS source (the key, obviously, not being on IPFS).  The encrypted video played correctly.  Closes #21 .